### PR TITLE
Invites tracker fixes

### DIFF
--- a/events/inviteCreate.js
+++ b/events/inviteCreate.js
@@ -1,0 +1,11 @@
+module.exports = (client, invite) => {
+    client.guilds.cache.get(config.server_id).invites.fetch().then(guildInvites => {
+        let invites = []
+
+        guildInvites.forEach(invite => {
+            invites.push({ code: invite.code, inviter: invite.inviter.id, uses: invite.uses })
+        });
+
+        fs.writeFileSync("invites/cache.json", JSON.stringify(invites));
+    });
+}


### PR DESCRIPTION
Two problems which impact invites tracking are fixed by this PR : 
- if the invite used by the new member can't be found, the bot sends the greetings message anyways
- new invitations are now added to cache right on their creation