### PR TITLE
Forgot to add GUILD_INVITES intent to the bot

### DIFF
--- a/events/inviteCreate.js
+++ b/events/inviteCreate.js
@@ -1,4 +1,7 @@
 module.exports = (client, invite) => {
+    const config = require('../config.json');
+    const fs = require('fs');
+
     client.guilds.cache.get(config.server_id).invites.fetch().then(guildInvites => {
         let invites = []
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const Discord = require('discord.js');
-const client = new Discord.Client({ intents: [Discord.Intents.FLAGS.GUILDS, Discord.Intents.FLAGS.GUILD_MESSAGES, Discord.Intents.FLAGS.GUILD_MEMBERS] });
+const client = new Discord.Client({ intents: [Discord.Intents.FLAGS.GUILDS, Discord.Intents.FLAGS.GUILD_MESSAGES, Discord.Intents.FLAGS.GUILD_MEMBERS, Discord.Intents.FLAGS.GUILD_INVITES] });
 
 require('dotenv').config();
 


### PR DESCRIPTION
Two problems which impact invites tracking are fixed by this PR : 
- if the invite used by the new member can't be found, the bot sends the greetings message anyways
- new invitations are now added to cache right on their creation